### PR TITLE
Proper error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ rustc-args = ["--cfg", "docsrs"]
 all-features = true
 
 [dependencies]
+thiserror = "1.0.57"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub fn new_header(sample_rate:u32, bits_per_sample:u16, is_float:bool, is_mono:b
 }
 
 /// Read from Wav file
-pub fn read_from_file(file_in: std::fs::File) -> Result<(WavHeader, Vec<f32>), &'static str> {
+pub fn read_from_file(file_in: std::fs::File) -> Result<(WavHeader, Vec<f32>), reader::DecodeError> {
     match reader::from_file(file_in) {
         Ok(wd) => { Ok((wd.header, wd.samples)) },
         Err(e) => Err(e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,16 +143,13 @@ pub fn read_from_file(file_in: std::fs::File) -> Result<(WavHeader, Vec<f32>), r
     }
 }
 /// Write to Wav file
-pub fn write_to_file(file_out: &mut std::fs::File, header: &WavHeader, samples: &Vec<f32>) -> Result<(), &'static str> {
+pub fn write_to_file(file_out: &mut std::fs::File, header: &WavHeader, samples: &Vec<f32>) -> Result<(), writer::EncoderError> {
     writer::f32samples_to_file(file_out, header, samples)
 }
 
 /// Write Wav data
-pub fn write_to_bytes(head: &WavHeader, samples: &Vec<f32>) -> Result<Vec<u8>, &'static str> {
-    match to_bytes(head, samples) {
-        Ok(v) => Ok(v),
-        Err(e) => Err(e),
-    }
+pub fn write_to_bytes(head: &WavHeader, samples: &Vec<f32>) -> Result<Vec<u8>, writer::EncoderError> {
+    to_bytes(head, samples)
 }
 
 /// convert i16 to f32 samples

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -31,6 +31,8 @@ pub enum DecodeError {
         expected: &'static [u32],
         found: u32,
     },
+    #[error("Unsupported wav encoding, module only supports PCM data")]
+    UnsupportedEncoding,
     #[error("Failed to open file")]
     FileOpen {
         #[source]
@@ -368,11 +370,7 @@ impl Reader {
                         }),
                     }
                 },
-                _ => return Err(DecodeError::UnsupportedWav {
-                    attribute: "",
-                    expected: &[8, 16, 24, 32],
-                    found: h.bits_per_sample as u32,
-                }),
+                _ => return Err(DecodeError::UnsupportedEncoding),
             }
         }
         Ok(result)


### PR DESCRIPTION
### The problem
As of now, error codes are returned as `&'static str`, which is fine, but it leads to some generic and sometimes not all that helpful errors when debugging. It is also not very rust idiomatic.

### Changes
I've added proper error enums which implement `std::error::Error` by using the `thiserror` crate.
I also changed the code to use these new errors instead of the constant strings used before.

With this I am to make the possible error points more clear and more rust idiomatic.

### Todo
I have not added any documentation for the new errors yet. I am planning on doing so, however I have not had the time yet.