### PR TITLE
fix u8 to f32 conversion

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -343,7 +343,7 @@ impl Reader {
                             for _ in 0..num_sample {
                                 // 0..255
                                 let lv = self.read_u8().unwrap_or(0);
-                                let fv = (lv - 128) as f32;
+                                let fv = lv.wrapping_sub(128) as i8 as f32 / (0xFF as f32 / 2.0);
                                 result.push(fv);
                             }
                         },


### PR DESCRIPTION
Here is a file to test

[eightbits.zip](https://github.com/user-attachments/files/18043764/eightbits.zip)

Otherwise, the program will panic due to overflow. Worse, the program works just fine but your ears don't.